### PR TITLE
Fix non-instatiable service when server name isn't default

### DIFF
--- a/server/meson.build
+++ b/server/meson.build
@@ -8,7 +8,8 @@ server_service = executable(
         server_dep,
     ],
     install: true,
-    install_dir: join_paths(get_option('prefix'), get_option('libexecdir'))
+    install_dir: join_paths(get_option('prefix'), get_option('libexecdir')),
+    install_rpath: join_paths(get_option('prefix'), get_option('libdir'), 'dleyna-server')
 )
 
 server_name = get_option('server_name')

--- a/server/meson.build
+++ b/server/meson.build
@@ -11,13 +11,15 @@ server_service = executable(
     install_dir: join_paths(get_option('prefix'), get_option('libexecdir'))
 )
 
+server_name = get_option('server_name')
+
 dbus_conf = configuration_data()
-dbus_conf.set('DLEYNA_SERVER_NAME', get_option('server_name'))
+dbus_conf.set('DLEYNA_SERVER_NAME', server_name)
 dbus_conf.set('libexecdir', join_paths(get_option('prefix'), get_option('libexecdir')))
 
 configure_file(
     input: 'com.intel.dleyna-server.service.in',
-    output: 'com.intel.dleyna-server.service',
+    output: server_name + '.service',
     configuration: dbus_conf,
     install: true,
     install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'dbus-1/services')


### PR DESCRIPTION
This broke during the meson port.